### PR TITLE
Update inherited_lorentzian.py documentation

### DIFF
--- a/pyspeckit/spectrum/models/inherited_lorentzian.py
+++ b/pyspeckit/spectrum/models/inherited_lorentzian.py
@@ -15,12 +15,26 @@ import numpy
 
 def lorentzian(x,A,dx,w, return_components=False):
     """
-    Returns a 1-dimensional lorentzian of form
-    A*2*pi*w/((x-dx)**2 + ((w/2)**2))
+    Returns a 1-dimensional lorentzian of the form
+    A/(2*pi)*w/((x-dx)**2 + ((w/2)**2))
     
-    [amplitude,center,width]
+             1             w
+        A ------- --------------------
+           2  pi   (x-dx)^2 + (w/2)^2
+    
+     A = Amplitude
+    dx = Center
+     w = Full Width at Half Maximum
+    
+    Also known as the "Cauchy Distribution"
+    
+    Guesses should be of the form [amplitude,center,width]
 
     return_components does nothing but is required by all fitters
+    
+    Additional readings:
+    http://mathworld.wolfram.com/CauchyDistribution.html
+    https://en.wikipedia.org/wiki/Cauchy_distribution
     
     """
     x = numpy.array(x) # make sure xarr is no longer a spectroscopic axis


### PR DESCRIPTION
Added/corrected documentation for the Lorentzian fitter.

Changed:
   Formula definition from A_2_pi_w/((x-dx)__2 + ((w/2)__2)) to A/(2_pi)_w/((x-dx)__2 + ((w/2)_*2))

Added:
   Lorentzian Distribution's alternate name, "Cauchy Distribution"
   A detailed formula
   Variable definitions
   Clarification on guesses formatting
   Additional readings
